### PR TITLE
Performance optimization of populatedata.sql and new step in readme.md

### DIFF
--- a/demos/sqlserver2022/IQP/dopfeedback/readme.md
+++ b/demos/sqlserver2022/IQP/dopfeedback/readme.md
@@ -21,6 +21,7 @@ This demo will show you how to see how to get consistent performance with less C
 1. Execute **proc.sql** to create a stored procedure
 1. Execute **dopxe.sql** to create an XEvent session.
 1. Use SSMS to Watch the XE session to see Live Data
+1. Change the value for -S (servername) in **workload_index_scan_users.cmd** to connect to your instance of SQL Server 2022 CRP2.0.
 1. Run **workload_index_scan_users.cmd** from a command prompt.
 1. Observe the XEvent data. It will take about 10mins to see XXXX event which means the final DOP setting to achieve stability.
 1. Cancel the workload from the cmd script

--- a/demos/sqlserver2022/IQP/dopfeedback/workload_index_scan_users.cmd
+++ b/demos/sqlserver2022/IQP/dopfeedback/workload_index_scan_users.cmd
@@ -1,1 +1,1 @@
-"c:\Program Files\Microsoft Corporation\RMLUtils\ostress" -E -Q"EXEC Warehouse.GetStockItemsbySupplier 4;" -n1 -r200 -q -oworkload_wwi_regress -dWideWorldImporters
+"c:\Program Files\Microsoft Corporation\RMLUtils\ostress" -E -Q"EXEC Warehouse.GetStockItemsbySupplier 4;" -S"SERVER\INSTANCE" -n1 -r200 -q -oworkload_wwi_regress -dWideWorldImporters


### PR DESCRIPTION
Added -S to osstress call.
Included extra step in readme.md to make a change to server name in workload_index_scan_users.cmd
Changed populatedata.sql to improve performance by using smaller transactions (less logfile growth) and showcase the new GENERATE_SERIES relational operator.